### PR TITLE
Header Component - Add Level 2 Support

### DIFF
--- a/src/header/Header.tsx
+++ b/src/header/Header.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 
 interface HeaderProps {
+  level: 1 | 2
   text: string
 }
 
 const Header = ({
+  level,
   text
 }: HeaderProps) => {
   return (
-    <h1>{text}</h1>
+    level === 1 ? <h1>{text}</h1> : <h2>{text}</h2>
   )
 };
 


### PR DESCRIPTION
Simple PR that adds "Level 2 Support" for header; meaning, the user can use `h1` or `h2`.

This is one of many PR's that will be used to test the `auto` tool.